### PR TITLE
Rename to interviewscreeners to attendance. Because, English

### DIFF
--- a/db/migrate/20150606182214_rename_interviewscreener_to_attendance.rb
+++ b/db/migrate/20150606182214_rename_interviewscreener_to_attendance.rb
@@ -1,0 +1,5 @@
+class RenameInterviewscreenerToAttendance < ActiveRecord::Migration
+  def change
+    rename_table :interviewscreeners, :attendances
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150606164633) do
+ActiveRecord::Schema.define(version: 20150606182214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "attendances", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "interview_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "attendances", ["interview_id"], name: "index_attendances_on_interview_id", using: :btree
+  add_index "attendances", ["user_id"], name: "index_attendances_on_user_id", using: :btree
 
   create_table "candidates", force: :cascade do |t|
     t.string   "firstname"
@@ -43,16 +53,6 @@ ActiveRecord::Schema.define(version: 20150606164633) do
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
   end
-
-  create_table "interviewscreeners", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "interview_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
-  end
-
-  add_index "interviewscreeners", ["interview_id"], name: "index_interviewscreeners_on_interview_id", using: :btree
-  add_index "interviewscreeners", ["user_id"], name: "index_interviewscreeners_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "firstname"


### PR DESCRIPTION
Renaming `Interviewscreener` to `Attendance`, as in interview attendance.

:eyes: @EmilyMB @miranmirza 
